### PR TITLE
rh-python35 on RHEL 7 machine

### DIFF
--- a/roles/rh-python35/tasks/main.yml
+++ b/roles/rh-python35/tasks/main.yml
@@ -6,6 +6,7 @@
 
 - name: Install centos-release-scl (package with the repo file)
   yum: name=centos-release-scl state=installed
+  when: ansible_distribution == 'CentOS'
 
 - name: Install rh python35 software collection
   yum: name=rh-python35 state=present


### PR DESCRIPTION
Package centos-release-scl is available only on CentOS machine, not applicable on RHEL.