### PR TITLE
Update qe server setup for CI

### DIFF
--- a/roles/qe-server-user/defaults/main.yml
+++ b/roles/qe-server-user/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+usmqe_setup_repo: 'https://github.com/Tendrl/usmqe-setup.git'
+usmqe_tests_repo: 'https://github.com/Tendrl/usmqe-tests.git'
+ansible_gluster_repo: 'https://github.com/dahorak/ansible-gluster.git'

--- a/roles/qe-server-user/defaults/main.yml
+++ b/roles/qe-server-user/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 usmqe_setup_repo: 'https://github.com/Tendrl/usmqe-setup.git'
+usmqe_setup_version: 'master'
 usmqe_tests_repo: 'https://github.com/Tendrl/usmqe-tests.git'
+usmqe_tests_version: 'master'
 ansible_gluster_repo: 'https://github.com/dahorak/ansible-gluster.git'
+ansible_gluster_version: 'master'

--- a/roles/qe-server-user/tasks/main.yml
+++ b/roles/qe-server-user/tasks/main.yml
@@ -17,6 +17,9 @@
    - name: 'usmqe-tests'
      repo: 'https://github.com/Tendrl/usmqe-tests.git'
      version: 'master'
+   - name: 'ansible-gluster'
+     repo: 'https://github.com/dahorak/ansible-gluster.git'
+     version: 'master'
 
 # Install all requirements of usmqe-tests repository via pip from PyPI
 # locally for usmqe user and rh-python35 software collection only.
@@ -32,3 +35,9 @@
   with_items:
    - 'source /opt/rh/rh-python35/enable'
    - "export X_SCLS=$(scl enable rh-python35 'echo $X_SCLS')"
+
+- name: Add ANSIBLE_LIBRARY into in ~/.bashrc
+  lineinfile:
+    dest={{ ansible_user_dir }}/.bashrc
+    state=present
+    line="export ANSIBLE_LIBRARY={{ ansible_user_dir }}/ansible-gluster/"

--- a/roles/qe-server-user/tasks/main.yml
+++ b/roles/qe-server-user/tasks/main.yml
@@ -13,13 +13,13 @@
   with_items:
    - name: 'usmqe-setup'
      repo: "{{ usmqe_setup_repo }}"
-     version: 'master'
+     version: "{{ usmqe_setup_version }}"
    - name: 'usmqe-tests'
      repo: "{{ usmqe_tests_repo }}"
-     version: 'master'
+     version: "{{ usmqe_tests_version }}"
    - name: 'ansible-gluster'
      repo: "{{ ansible_gluster_repo }}"
-     version: 'master'
+     version: "{{ ansible_gluster_version }}"
 
 # Install all requirements of usmqe-tests repository via pip from PyPI
 # locally for usmqe user and rh-python35 software collection only.

--- a/roles/qe-server-user/tasks/main.yml
+++ b/roles/qe-server-user/tasks/main.yml
@@ -12,13 +12,13 @@
     update=no
   with_items:
    - name: 'usmqe-setup'
-     repo: 'https://github.com/Tendrl/usmqe-setup.git'
+     repo: "{{ usmqe_setup_repo }}"
      version: 'master'
    - name: 'usmqe-tests'
-     repo: 'https://github.com/Tendrl/usmqe-tests.git'
+     repo: "{{ usmqe_tests_repo }}"
      version: 'master'
    - name: 'ansible-gluster'
-     repo: 'https://github.com/dahorak/ansible-gluster.git'
+     repo: "{{ ansible_gluster_repo }}"
      version: 'master'
 
 # Install all requirements of usmqe-tests repository via pip from PyPI


### PR DESCRIPTION
I have added installation of Jonathan's ansible gluster module and moved both url and versions of git repositories into variables, which would allow ah hoc tweaking if needed.