### PR TITLE
role qe-server: wrap variable by quotes for backward compatibility

### DIFF
--- a/roles/qe-server-user/tasks/main.yml
+++ b/roles/qe-server-user/tasks/main.yml
@@ -31,7 +31,7 @@
   lineinfile:
     dest={{ ansible_user_dir }}/.bashrc
     state=present
-    line={{ item }}
+    line="{{ item }}"
   with_items:
    - 'source /opt/rh/rh-python35/enable'
    - "export X_SCLS=$(scl enable rh-python35 'echo $X_SCLS')"


### PR DESCRIPTION
role qe-server: wrap variable by quotes for backward compatibility with ansible 1.9