### PR TITLE
Update tendrl-gluster-integration role

### DIFF
--- a/roles/tendrl-gluster-integration/tasks/main.yml
+++ b/roles/tendrl-gluster-integration/tasks/main.yml
@@ -1,4 +1,13 @@
 #
+# workaround for https://github.com/Tendrl/gluster-integration/issues/151
+# TODO: remove gstatus installation after the issue is resolved
+#
+
+- name: Install gstatus
+  yum:
+    name: https://github.com/gluster/gstatus/raw/master/rpms/gstatus-0.64-3.el7.x86_64.rpm
+
+#
 # installation
 #
 

--- a/roles/tendrl-gluster-integration/tasks/main.yml
+++ b/roles/tendrl-gluster-integration/tasks/main.yml
@@ -16,4 +16,3 @@
 
 - include: binary.yml
   when: install_from == "packages"
-

--- a/roles/tendrl-gluster-integration/tasks/main.yml
+++ b/roles/tendrl-gluster-integration/tasks/main.yml
@@ -8,12 +8,3 @@
 - include: binary.yml
   when: install_from == "packages"
 
-#
-# post installation configuration
-#
-
-- name: Start and enable tendrl-gluster-integration service
-  service:
-    name=tendrl-gluster-integration
-    state=started
-    enabled=yes


### PR DESCRIPTION
Drop `tendrl-gluster-integration` service starting according to:
https://github.com/Tendrl/gluster-integration/issues/148#issuecomment-281998249

Add `gstatus` installation because of:
https://github.com/Tendrl/gluster-integration/issues/151
`gstatus` installation should be removed after the issue is resolved.