### PR TITLE
Fix ceph ansible local

### DIFF
--- a/ceph_ansible.yml
+++ b/ceph_ansible.yml
@@ -6,7 +6,8 @@
       setup:
 
 - name: Install ceph-ansible and install Ceph
-  hosts: qe_server
+  hosts: localhost
+  connection: local
   user: root
   roles:
     - ceph-ansible

--- a/ceph_ansible.yml
+++ b/ceph_ansible.yml
@@ -8,6 +8,5 @@
 - name: Install ceph-ansible and install Ceph
   hosts: localhost
   connection: local
-  user: root
   roles:
     - ceph-ansible


### PR DESCRIPTION
This pull request fixes https://github.com/Tendrl/usmqe-setup/issues/43 by allowing usmqe user to become root via sudo and using this power to execute `ceph-ansible` role locally under root user.