### PR TITLE
role qe-evidence-probe-journald

### DIFF
--- a/qe_evidence.journald_export_example.yml
+++ b/qe_evidence.journald_export_example.yml
@@ -1,0 +1,13 @@
+---
+
+# Example usage of qe-evidence-probe-journald role.
+
+- name: Export journald logs for given services
+  hosts: all
+  user: root
+  vars:
+    evidence_journald_services:
+      - sshd
+      - auditd
+  roles:
+    - qe-evidence-probe-journald

--- a/roles/qe-evidence-probe-journald/README.rst
+++ b/roles/qe-evidence-probe-journald/README.rst
@@ -1,0 +1,19 @@
+=================================
+ qe-evidence-probe-journald role
+=================================
+
+This ansible role automates and standardizes the way QE team extracts
+information from journald log database.
+
+Description
+-----------
+
+This role creates temporary directory ``/tmp/journald-export/`` on a remote
+machine and stores there plain text files in `Journal Export Format`_ for every
+systemd service listed in ``evidence_journal_services`` variable.
+
+See `systemd.journal-fields man page`_ for full descrition of Journal Fields
+used in the export format.
+
+.. _`Journal Export Format`: https://www.freedesktop.org/wiki/Software/systemd/export/
+.. _`systemd.journal-fields man page`: https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html

--- a/roles/qe-evidence-probe-journald/defaults/main.yml
+++ b/roles/qe-evidence-probe-journald/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# List of services for which we export journal logs.
+evidence_journald_services:
+ - sshd

--- a/roles/qe-evidence-probe-journald/defaults/main.yml
+++ b/roles/qe-evidence-probe-journald/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 # List of services for which we export journal logs.
-evidence_journald_services:
- - sshd
+evidence_journald_services: []

--- a/roles/qe-evidence-probe-journald/tasks/main.yml
+++ b/roles/qe-evidence-probe-journald/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+
+- name: Fail if evidence_target variable is not defined
+  fail: msg="You need to define evidence target variable"
+  when: evidence_target is undefined
+  delegate_to: localhost
+
+# First of all, we need to create remote temporary directory, where we are
+# going to dump results of the probe.
+
+- name: Create temporary journald export directory
+  file: path=/tmp/journald-export/ state=directory
+
+# We also need to create a local directory for each remote machine (we are
+# going to rsync data from remote machines there).
+
+- name: Create local target directories
+  file:
+    path={{ evidence_target }}/{{ inventory_hostname }}/tmp/journald-export/
+    state=directory
+  delegate_to: localhost
+
+# Make sure that tools required for the probe are installed
+
+- name: Make sure systemd is installed
+  yum: name={{ item }} state=present
+  with_items:
+   - systemd
+
+# So that we can export data from journal database
+
+- name: Export journald logs
+  shell: 'journalctl -u {{ item }} -o export > {{ item }}.export'
+  args:
+    chdir: /tmp/journald-export/
+  with_items: '{{ evidence_journald_services }}'
+
+- name: Export list of boots
+  shell: 'journalctl --list-boots > list-boots'
+  args:
+    chdir: /tmp/journald-export/
+
+# Now rsync all the data dumps from remote machines.
+
+- name: Rsync result of the probe into local machine
+  synchronize:
+    src=/tmp/journald-export/
+    dest={{ evidence_target }}/{{ inventory_hostname }}/tmp/journald-export/
+    mode=pull
+    archive=yes
+
+# The last step: remove journald export directory
+
+- name: Remove temporary journald export directory
+  file: path=/tmp/journald-export/ state=absent


### PR DESCRIPTION
This role downloads exports from journald log database for given systemd
services.

Resolves https://github.com/Tendrl/usmqe-setup/issues/48