### PR TITLE
Retries epel package installation.

### DIFF
--- a/roles/epel/tasks/main.yml
+++ b/roles/epel/tasks/main.yml
@@ -21,6 +21,10 @@
   yum:
     name='https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version  }}.noarch.rpm'
     state=present
+  register: task_result
+  until: task_result|success
+  retries: 5
+  delay: 5
 
 # This is sane default for QE purposes. One should enable EPEL repository only
 # when needed.


### PR DESCRIPTION
This might fix problem with downloading epel-release-latest-7.noarch.rpm package like this:
```
fatal: [ci-usm2-gl1.localdomain]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "conf_file": null, 
            "disable_gpg_check": false, 
            "disablerepo": null, 
            "enablerepo": null, 
            "exclude": null, 
            "install_repoquery": true, 
            "list": null, 
            "name": [
                "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
            ], 
            "state": "present", 
            "update_cache": false, 
            "validate_certs": true
        }, 
        "module_name": "yum"
    }, 
    "msg": "Failure downloading https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm, 'NoneType' object has no attribute 'read'"
}
```