### PR TITLE
remove tendrl-{ceph, gluster}-integration roles from playbooks

### DIFF
--- a/ci_default.yml
+++ b/ci_default.yml
@@ -18,14 +18,10 @@
 
 - include: gluster.yml
   when: groups.gluster is defined
-- include: tendrl_gluster.yml
-  when: groups.gluster is defined
 - include: gluster_peers_bricks.yml
   when: groups.gluster is defined
 
 - include: ceph_prereq.yml
-  when: groups.ceph_osd is defined and groups.ceph_mon is defined
-- include: tendrl_ceph.yml
   when: groups.ceph_osd is defined and groups.ceph_mon is defined
 
 # workaround according to https://github.com/Tendrl/api/issues/86#issuecomment-285063914

--- a/tendrl_gluster_peers_bricks.yml
+++ b/tendrl_gluster_peers_bricks.yml
@@ -7,6 +7,5 @@
 - include: qe_pre_installation_tasks.yml
 - include: tendrl_server.yml
 - include: tendrl_node.yml
-- include: tendrl_gluster.yml
 - include: gluster.yml
 - include: gluster_peers_bricks.yml


### PR DESCRIPTION
`tendrl-ceph-integration` and `tendrl-gluster-integration` roles are going to be removed from tendrl installation playbooks. `tendrl-node-agent` should install them.

Based on:
https://github.com/Tendrl/gluster-integration/issues/133#issuecomment-288409086
https://github.com/Tendrl/documentation/wiki/Tendrl-Package-Installation-Reference