### PR TITLE
WORKAROUND: run partprobe on ceph OSD nodes

### DIFF
--- a/ci_default.yml
+++ b/ci_default.yml
@@ -42,3 +42,11 @@
       service:
         name=tendrl-node-agent
         state=started
+
+# WORKAROUND for https://github.com/ceph/ceph-ansible/issues/1403
+# TODO: delete after resolving
+- hosts: ceph_osd
+  remote_user: root
+  tasks:
+    - name: Run partprobe
+      shell: partprobe || true


### PR DESCRIPTION
Workaround for https://github.com/ceph/ceph-ansible/issues/1403