### PR TITLE
Separate Ceph and Gluster repos to new playbooks

### DIFF
--- a/ceph_prereq.yml
+++ b/ceph_prereq.yml
@@ -2,11 +2,8 @@
 - include: ceph_ansible.yml
   when: groups.mons is defined
 
+# Install centos-release-ceph package with Ceph Repos
 - hosts: ceph_mon:ceph_osd
   remote_user: root
-  tasks: 
-    - name: Install centos-release-ceph package
-      yum: 
-        name: centos-release-ceph
-        state: present
-      
+  roles:
+    - ceph-centos-repo

--- a/gluster.yml
+++ b/gluster.yml
@@ -7,4 +7,5 @@
   vars:
     install_from: packages
   roles:
+    - gluster-centos-repo
     - gluster-centos

--- a/gluster_peers_bricks.yml
+++ b/gluster_peers_bricks.yml
@@ -7,6 +7,7 @@
 - hosts: gluster
   remote_user: root
   roles:
-  - gluster-centos
-  - qe-gluster-peers
-  - qe-gluster-bricks
+    - gluster-centos-repo
+    - gluster-centos
+    - qe-gluster-peers
+    - qe-gluster-bricks

--- a/roles/ceph-centos-repo/README.rst
+++ b/roles/ceph-centos-repo/README.rst
@@ -1,0 +1,5 @@
+================
+Ceph-centos-repo
+================
+
+This installs Centos SIG Ceph repo.

--- a/roles/ceph-centos-repo/defaults/main.yml
+++ b/roles/ceph-centos-repo/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+centos_ceph_version_package: centos-release-ceph

--- a/roles/ceph-centos-repo/tasks/main.yml
+++ b/roles/ceph-centos-repo/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Add Ceph YUM repo (install centos-release-ceph package)
+  yum:
+    name: "{{ centos_ceph_version_package }}"
+    state: present

--- a/roles/gluster-centos-repo/README.rst
+++ b/roles/gluster-centos-repo/README.rst
@@ -1,0 +1,5 @@
+===================
+Gluster-centos-repo
+===================
+
+This role adds Centos gluster repo.

--- a/roles/gluster-centos-repo/defaults/main.yml
+++ b/roles/gluster-centos-repo/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+gluster_repo_url: "http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.9"

--- a/roles/gluster-centos-repo/tasks/main.yml
+++ b/roles/gluster-centos-repo/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Add Gluster YUM repo
+  yum_repository:
+    name: gluster
+    description: Gluster YUM repo
+    baseurl: "{{ gluster_repo_url }}"

--- a/roles/gluster-centos/defaults/main.yml
+++ b/roles/gluster-centos/defaults/main.yml
@@ -1,3 +1,0 @@
----
-# when true, tendrl-api is installed from a source repository
-gluster_repo_url: http://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.9

--- a/roles/gluster-centos/tasks/main.yml
+++ b/roles/gluster-centos/tasks/main.yml
@@ -1,9 +1,3 @@
-- name: Add Gluster YUM repo
-  yum_repository:
-    name: gluster
-    description: Gluster YUM repo
-    baseurl: "{{ gluster_repo_url }}"
-
 - name: Install GlusterFS
   yum:
     name="{{ item }}"


### PR DESCRIPTION
We need to have separated playbooks or roles for configuring Ceph and Gluster repo, because Tendrl should be able to install Ceph and Gluster cluster itself but it requires the proper repositories configured.