### PR TITLE
ci_tendrl_cluster.yml: playbook for installation of tendrl cluster without Ceph or Gluster cluster

### DIFF
--- a/ci_tendrl_cluster.yml
+++ b/ci_tendrl_cluster.yml
@@ -1,0 +1,58 @@
+---
+# Perform following tasks, when applicable
+# (e.g. there are nodes in gluster or ceph_* group)
+# * Configure firewall
+# * Install Tendrl server.
+# * Install Tendrl storage nodes.
+# * Add Gluster repo.
+# * Add Ceph repos.
+- include: qe_pre_installation_tasks.yml
+
+# configure firewall
+- include: firewall_tendrl.yml
+- include: firewall_tendrl_workaround.yml
+
+- include: qe_reboot.yml
+
+- include: tendrl_server.yml
+
+- include: tendrl_node.yml
+
+# Add Centos Gluster YUM repo
+- hosts: gluster
+  remote_user: root
+  roles:
+    - gluster-centos-repo
+
+# Install centos-release-ceph package with Ceph Repos
+- hosts: ceph_mon:ceph_osd
+  remote_user: root
+  roles:
+    - ceph-centos-repo
+
+# workaround according to https://github.com/Tendrl/api/issues/86#issuecomment-285063914
+# TODO: delete after resolving
+- hosts: usm_nodes
+  remote_user: root
+  tasks:
+    - name: Stop tendrl-node-agent daemon
+      service:
+        name=tendrl-node-agent
+        state=stopped
+
+    # immediate restart doesn't work
+    - pause:
+        seconds: 20
+
+    - name: Start tendrl-node-agent daemon
+      service:
+        name=tendrl-node-agent
+        state=started
+
+# WORKAROUND for https://github.com/ceph/ceph-ansible/issues/1403
+# TODO: delete after resolving
+- hosts: ceph_osd
+  remote_user: root
+  tasks:
+    - name: Run partprobe
+      shell: partprobe || true


### PR DESCRIPTION
This playbook perform following tasks, when applicable (e.g. there are nodes in gluster or ceph_* group)
* Configure firewall
* Install Tendrl server.
* Install Tendrl storage nodes.
* Add Gluster repo.
* Add Ceph repos.