### PR TITLE
Tendrl release v1.2.2 updates

### DIFF
--- a/roles/ceph-installer-repo/README.rst
+++ b/roles/ceph-installer-repo/README.rst
@@ -1,0 +1,14 @@
+====================
+Ceph-installer repos
+====================
+
+This role enables following repositories with ceph-installer and dependencies
+and installs its public gpg rpm key (if applicable).
+
+- `ceph-installer`_
+- `ceph-ansible`_
+- `ktdreyer/ceph-installer-dependencies`_
+
+.. _`ceph-installer`: https://shaman.ceph.com/api/repos/ceph-installer/master/latest/centos/7/noarch/noarch
+.. _`ceph-ansible`: https://shaman.ceph.com/api/repos/ceph-ansible/master/latest/centos/7/noarch/noarch
+.. _`ktdreyer/ceph-installer-dependencies`: https://copr.fedorainfracloud.org/coprs/ktdreyer/ceph-installer/repo/epel-7/ktdreyer-ceph-installer-epel-7.repo

--- a/roles/ceph-installer-repo/tasks/main.yml
+++ b/roles/ceph-installer-repo/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Add ceph-installer repo
+  yum_repository:
+    name: ceph-installer
+    description: "Ceph-installer repo"
+    baseurl: "https://shaman.ceph.com/api/repos/ceph-installer/master/latest/centos/7/noarch/noarch"
+    gpgcheck: no
+
+- name: Add ceph-ansible repo
+  yum_repository:
+    name: ceph-ansible
+    description: "Ceph-ansible repo"
+    baseurl: "https://shaman.ceph.com/api/repos/ceph-ansible/master/latest/centos/7/noarch/noarch"
+    gpgcheck: no
+
+
+- name: Add ktdreyer-ceph-installer repo
+  yum_repository:
+    name: ktdreyer-ceph-installer
+    description: "Copr repo for ceph-installer owned by ktdreyer"
+    baseurl: "https://copr-be.cloud.fedoraproject.org/results/ktdreyer/ceph-installer/epel-7-x86_64/"
+    gpgcheck: yes
+    skip_if_unavailable: yes
+
+- name: Add public key for ktdreyer-ceph-installer repo
+  rpm_key:
+    key="https://copr-be.cloud.fedoraproject.org/results/ktdreyer/ceph-installer/pubkey.gpg"

--- a/roles/ceph-installer/README.rst
+++ b/roles/ceph-installer/README.rst
@@ -1,0 +1,5 @@
+==============
+Ceph-installer
+==============
+
+This role installs ceph-installer package and dependencies.

--- a/roles/ceph-installer/tasks/main.yml
+++ b/roles/ceph-installer/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Install ceph-installer
+  yum:
+    name="ceph-installer"
+    state=latest

--- a/roles/tendrl-node-agent/tasks/main.yml
+++ b/roles/tendrl-node-agent/tasks/main.yml
@@ -19,6 +19,14 @@
     regexp='^etcd_connection:*'
     line="etcd_connection{{ ':' }} {{ groups['usm_server'][0] }}"
 
+# https://github.com/Tendrl/documentation/wiki/Tendrl-release-v1.2.2
+- name: Add provisioner/ceph tag in node-agent.conf.yaml (on tendrl-server)
+  lineinfile:
+    dest=/etc/tendrl/node-agent/node-agent.conf.yaml
+    insertafter='^tags:$'
+    line="  - provisioner/ceph"
+  when: "'usm_server' in group_names"
+
 - name: Start and enable tendrl-node-agent daemon
   service:
     name=tendrl-node-agent

--- a/tendrl_server.yml
+++ b/tendrl_server.yml
@@ -2,15 +2,18 @@
 #
 # Install Tendrl server
 #
-- hosts: usm_server 
+- hosts: usm_server
   remote_user: root
   vars:
     install_from: packages
   roles:
     - etcd
     - tendrl-repo
+    - ceph-installer-repo
     - { role: epel, epel_enabled: 1 } # based on https://github.com/Tendrl/tendrl-api/issues/25
     - tendrl-api
+    - tendrl-node-agent
+    - ceph-installer
     - tendrl-dashboard
     - tendrl-performance-monitoring
     - { role: epel, epel_enabled: 0 }


### PR DESCRIPTION
Install ceph-installer on Tendrl server.
Install tendrl-node-agent on Tendrl server.
Configure proper tags for tendrl-node-agent on Tendrl server.