### PR TITLE
tendrl-api: add new line to password file

### DIFF
--- a/qe_tendrl_admin.yml
+++ b/qe_tendrl_admin.yml
@@ -13,5 +13,5 @@
 
     - name: Change password in /root/password file
       copy:
-        content="{{ new_password }}"
+        content="{{ new_password }}\n"
         dest=/root/password

--- a/roles/tendrl-api/tasks/main.yml
+++ b/roles/tendrl-api/tasks/main.yml
@@ -56,6 +56,6 @@
 
 - name: Store admin password to /root/password file
   copy:
-    content="{{ admin_password.stdout }}"
+    content="{{ admin_password.stdout }}\n"
     dest=/root/password
   when: admin_password.changed


### PR DESCRIPTION
The admin password is stored in `/root/password` file without the ending new line:
```
# cat password 
8b725666[root@usm-server ~]# 
```
This patch will add new line at the end of the password file.