### PR TITLE
re-enable epel repository

### DIFF
--- a/tendrl_ceph.yml
+++ b/tendrl_ceph.yml
@@ -9,4 +9,3 @@
   roles:
     - { role: epel, epel_enabled: 1 } # based on https://github.com/Tendrl/node_agent/issues/75
     - tendrl-ceph-integration
-    - { role: epel, epel_enabled: 0 }

--- a/tendrl_gluster.yml
+++ b/tendrl_gluster.yml
@@ -9,4 +9,3 @@
   roles:
     - { role: epel, epel_enabled: 1 } # based on https://github.com/Tendrl/node_agent/issues/75
     - tendrl-gluster-integration
-    - { role: epel, epel_enabled: 0 }

--- a/tendrl_node.yml
+++ b/tendrl_node.yml
@@ -12,4 +12,3 @@
     - tendrl-commons
     - tendrl-node-agent
     - tendrl-node-monitoring
-    - { role: epel, epel_enabled: 0 }

--- a/tendrl_server.yml
+++ b/tendrl_server.yml
@@ -16,7 +16,6 @@
     - ceph-installer
     - tendrl-dashboard
     - tendrl-performance-monitoring
-    - { role: epel, epel_enabled: 0 }
 
   post_tasks:
     - debug: var=hostvars[groups['usm_server'][0]]['admin_password']


### PR DESCRIPTION
Since Tendrl itself finally starts to cover package installation to some
degree, we need to have epel enabled from now on for this to work.

Note: when you run these playbooks on RHEL, the setup fails - there is
no change in the check. This is a feature: enabling EPEL in such case
is a blocker bug and we need to catch it as soon as possible.

Based on @mkudlej feedback.