### PR TITLE
Install python-netaddr on qe_server

### DIFF
--- a/roles/qe-server/tasks/main.yml
+++ b/roles/qe-server/tasks/main.yml
@@ -127,12 +127,13 @@
 # other tools
 #
 
-- name: Install other useful tools
+- name: Install other dependencies and useful tools
   yum: name={{ item }} state=installed enablerepo=epel
   with_items:
    - createrepo
    - git
    - htop
+   - python-netaddr
    - rpmdeplint
    - rpmlint
    - tmux


### PR DESCRIPTION
* python-netaddr is required for ipaddr jinja2 filter