### PR TITLE
enable glusterd service

### DIFF
--- a/roles/gluster-centos/README.rst
+++ b/roles/gluster-centos/README.rst
@@ -2,4 +2,5 @@
  Gluster-centos
 ================
 
-This role installs gluster packages used by tendrl Tendrl project.
+This role installs gluster packages used by Tendrl project and enables
+glusterd service.

--- a/roles/gluster-centos/tasks/main.yml
+++ b/roles/gluster-centos/tasks/main.yml
@@ -27,7 +27,8 @@
   retries: 5
   delay: 5
 
-- name: Run glusterd service
+- name: Run and enable glusterd service
   service:
     name=glusterd
     state=started
+    enabled=yes


### PR DESCRIPTION
This adds enabling `glusterd` service after glusterfs is installed and `glusterd` started.