### PR TITLE
Allow different default NIC name (not only eth0).

### DIFF
--- a/roles/tendrl-api/tasks/main.yml
+++ b/roles/tendrl-api/tasks/main.yml
@@ -43,7 +43,7 @@
   replace:
     dest=/etc/tendrl/etcd.yml
     regexp="^  {{ ":" }}host{{ ":" }} .*"
-    replace="  {{ ":" }}host{{ ":" }} \'{{ hostvars[groups['usm_server'][0]]['ansible_eth0']['ipv4']['address'] }}\'"
+    replace="  {{ ":" }}host{{ ":" }} \'{{ hostvars[groups['usm_server'][0]]['ansible_default_ipv4']['address'] }}\'"
 
 # as documented in README file and deployment.adoc from Tendrl/documentation
 - name: Start and enable tendrl-api

--- a/roles/tendrl-performance-monitoring/tasks/main.yml
+++ b/roles/tendrl-performance-monitoring/tasks/main.yml
@@ -26,7 +26,7 @@
     - regexp: '^etcd_port:*'
       line: "etcd_port{{ ':' }} 2379"
     - regexp: '^time_series_db_server:*'
-      line: "time_series_db_server{{ ':' }} {{ ansible_eth0['ipv4']['address'] }}"
+      line: "time_series_db_server{{ ':' }} {{ ansible_default_ipv4['address'] }}"
     - regexp: '^time_series_db_port:*'
       line: "time_series_db_port{{ ':' }} 10080"
 


### PR DESCRIPTION
* use ansible_default_ipv4 instead of specific ansible_eth0.ipv4