### PR TITLE
Update main ci_* playbooks structure

### DIFF
--- a/ci_default.yml
+++ b/ci_default.yml
@@ -4,11 +4,8 @@
 # * Configure firewall
 # * Install Tendrl server.
 # * Install Tendrl storage nodes.
-# * Install Gluster nodes.
-# * Configure gluster trusted storage pool and create bricks 
-#   on all available devices on gluster nodes.
-# * Install Ceph nodes.
-# * Preconfigure ceph-ansible.
+# * Add Gluster repo.
+# * Add Ceph repos.
 - include: qe_pre_installation_tasks.yml
 
 # configure firewall
@@ -19,15 +16,20 @@
 
 - include: tendrl_server.yml
 
-- include: gluster.yml
-  when: groups.gluster is defined
-- include: gluster_peers_bricks.yml
-  when: groups.gluster is defined
-
-- include: ceph_prereq.yml
-  when: groups.ceph_osd is defined and groups.ceph_mon is defined
-
 - include: tendrl_node.yml
+
+# Add Centos Gluster YUM repo
+- hosts: gluster
+  remote_user: root
+  roles:
+    - gluster-centos-repo
+    - gluster-gdeploy-repo
+
+# Install centos-release-ceph package with Ceph Repos
+- hosts: ceph_mon:ceph_osd
+  remote_user: root
+  roles:
+    - ceph-centos-repo
 
 # workaround according to https://github.com/Tendrl/api/issues/86#issuecomment-285063914
 # TODO: delete after resolving
@@ -42,7 +44,7 @@
     # immediate restart doesn't work
     - pause:
         seconds: 20
-  
+
     - name: Start tendrl-node-agent daemon
       service:
         name=tendrl-node-agent

--- a/ci_default_import.yml
+++ b/ci_default_import.yml
@@ -4,8 +4,11 @@
 # * Configure firewall
 # * Install Tendrl server.
 # * Install Tendrl storage nodes.
-# * Add Gluster repo.
-# * Add Ceph repos.
+# * Install Gluster nodes.
+# * Configure gluster trusted storage pool and create bricks
+#   on all available devices on gluster nodes.
+# * Install Ceph nodes.
+# * Preconfigure ceph-ansible.
 - include: qe_pre_installation_tasks.yml
 
 # configure firewall
@@ -16,20 +19,15 @@
 
 - include: tendrl_server.yml
 
+- include: gluster.yml
+  when: groups.gluster is defined
+- include: gluster_peers_bricks.yml
+  when: groups.gluster is defined
+
+- include: ceph_prereq.yml
+  when: groups.ceph_osd is defined and groups.ceph_mon is defined
+
 - include: tendrl_node.yml
-
-# Add Centos Gluster YUM repo
-- hosts: gluster
-  remote_user: root
-  roles:
-    - gluster-centos-repo
-    - gluster-gdeploy-repo
-
-# Install centos-release-ceph package with Ceph Repos
-- hosts: ceph_mon:ceph_osd
-  remote_user: root
-  roles:
-    - ceph-centos-repo
 
 # workaround according to https://github.com/Tendrl/api/issues/86#issuecomment-285063914
 # TODO: delete after resolving


### PR DESCRIPTION
* rename ci_tendrl_cluster.yml to ci_default.yml
  - install and configure Tendrl server and nodes
  - do not install and configure Ceph or Gluster
  - usable for cluster creation via Tendrl API/UI

* rename ci_default.yml to ci_default_import.yml
  - install and configure Tendrl server and nodes
  - install and configure Ceph or/and Gluster cluster
  - usable for cluster import testing via Tendrl API/UI