### PR TITLE
remove workaround

### DIFF
--- a/ci_default.yml
+++ b/ci_default.yml
@@ -31,25 +31,6 @@
   roles:
     - ceph-centos-repo
 
-# workaround according to https://github.com/Tendrl/api/issues/86#issuecomment-285063914
-# TODO: delete after resolving
-- hosts: usm_nodes
-  remote_user: root
-  tasks:
-    - name: Stop tendrl-node-agent daemon
-      service:
-        name=tendrl-node-agent
-        state=stopped
-
-    # immediate restart doesn't work
-    - pause:
-        seconds: 20
-
-    - name: Start tendrl-node-agent daemon
-      service:
-        name=tendrl-node-agent
-        state=started
-
 # WORKAROUND for https://github.com/ceph/ceph-ansible/issues/1403
 # TODO: delete after resolving
 - hosts: ceph_osd

--- a/ci_default_import.yml
+++ b/ci_default_import.yml
@@ -29,25 +29,6 @@
 
 - include: tendrl_node.yml
 
-# workaround according to https://github.com/Tendrl/api/issues/86#issuecomment-285063914
-# TODO: delete after resolving
-- hosts: usm_nodes
-  remote_user: root
-  tasks:
-    - name: Stop tendrl-node-agent daemon
-      service:
-        name=tendrl-node-agent
-        state=stopped
-
-    # immediate restart doesn't work
-    - pause:
-        seconds: 20
-
-    - name: Start tendrl-node-agent daemon
-      service:
-        name=tendrl-node-agent
-        state=started
-
 # WORKAROUND for https://github.com/ceph/ceph-ansible/issues/1403
 # TODO: delete after resolving
 - hosts: ceph_osd


### PR DESCRIPTION
This removes restarting node-agent as it is not described in any installation documentation. It was supposed to resolve issue with not detected cluster according to https://github.com/Tendrl/api/issues/86#issuecomment-285063914.

Cluster is now detected without restarting node-agent. This will resolve inactivity of `tendrl-node-monitoring` service. (https://github.com/Tendrl/dashboard/issues/361#issuecomment-303934353)