### PR TITLE
add and use gluster_peers playbook

### DIFF
--- a/ci_default_import.yml
+++ b/ci_default_import.yml
@@ -5,8 +5,7 @@
 # * Install Tendrl server.
 # * Install Tendrl storage nodes.
 # * Install Gluster nodes.
-# * Configure gluster trusted storage pool and create bricks
-#   on all available devices on gluster nodes.
+# * Configure gluster trusted storage pool.
 # * Install Ceph nodes.
 # * Preconfigure ceph-ansible.
 - include: qe_pre_installation_tasks.yml
@@ -21,7 +20,7 @@
 
 - include: gluster.yml
   when: groups.gluster is defined
-- include: gluster_peers_bricks.yml
+- include: gluster_peers.yml
   when: groups.gluster is defined
 
 - include: ceph_prereq.yml

--- a/gluster_peers.yml
+++ b/gluster_peers.yml
@@ -1,0 +1,9 @@
+---
+#
+# Create gluster trusted storage pool.
+#
+
+- hosts: gluster
+  remote_user: root
+  roles:
+    - qe-gluster-peers


### PR DESCRIPTION
* in ci_default_import playbook only create gluster trusted storage
pool, do not create bricks (pre-created bricks are not recognized by
Tendrl).