### PR TITLE
add tendrl-alerting role to tendrl_server.yml playbook

### DIFF
--- a/tendrl_server.yml
+++ b/tendrl_server.yml
@@ -16,6 +16,7 @@
     - ceph-installer
     - tendrl-dashboard
     - tendrl-performance-monitoring
+    - tendrl-alerting
 
   post_tasks:
     - debug: var=hostvars[groups['usm_server'][0]]['admin_password']


### PR DESCRIPTION
Adds installation of `tendrl-alerting` on tendrl server.