### PR TITLE
rename tendrl-apid service to tendrl-api

### DIFF
--- a/roles/tendrl-api/tasks/main.yml
+++ b/roles/tendrl-api/tasks/main.yml
@@ -48,7 +48,7 @@
 # as documented in README file and deployment.adoc from Tendrl/documentation
 - name: Start and enable tendrl-api
   service:
-    name=tendrl-apid
+    name=tendrl-api
     state=started
     enabled=yes
 


### PR DESCRIPTION
According to PR https://github.com/Tendrl/api/pull/196