### PR TITLE
Update evidence playbook for tendrl

### DIFF
--- a/qe_evidence.example.yml
+++ b/qe_evidence.example.yml
@@ -3,6 +3,9 @@
 # Instead of listing all configuration and log files to be fetched,
 # this playbook just downloads almost everything and then runs the probe.
 
+# For reference how to use evidence playbooks, see README file in qe-evidence
+# role: roles/qe-evidence/README.rst
+
 - name: Download all logs and all configuration from all machines
   hosts: all
   user: root

--- a/qe_evidence.tendrl.yml
+++ b/qe_evidence.tendrl.yml
@@ -74,7 +74,7 @@
     - qe-evidence-probe-journald
 
 - name: Download logs from Ceph Storage machines
-  hosts: ceph
+  hosts: ceph_osd:ceph_mon
   user: root
   vars:
     evidence_dirs:

--- a/qe_evidence.tendrl.yml
+++ b/qe_evidence.tendrl.yml
@@ -17,6 +17,7 @@
       - /proc/cpuinfo
       - /proc/meminfo
       - /etc/hosts
+      - /etc/machine-id
   roles:
     - qe-evidence
     - qe-evidence-probe

--- a/qe_evidence.tendrl.yml
+++ b/qe_evidence.tendrl.yml
@@ -16,6 +16,7 @@
       - /var/log/messages
       - /proc/cpuinfo
       - /proc/meminfo
+      - /etc/hosts
   roles:
     - qe-evidence
     - qe-evidence-probe

--- a/qe_evidence.tendrl.yml
+++ b/qe_evidence.tendrl.yml
@@ -40,11 +40,11 @@
       - /etc/carbon/
       - /etc/graphite-web/
       - /etc/ceph-installer/
-      - /var/log/tendrl
+      - /var/log/tendrl/
       - /var/log/httpd/
       - /var/log/carbon/
       - /var/log/graphite-web/
-      - /var/log/rabbitmq
+      - /var/log/rabbitmq/
     evidence_files:
       - /etc/collectd.conf
     evidence_journald_services:

--- a/qe_evidence.tendrl.yml
+++ b/qe_evidence.tendrl.yml
@@ -14,9 +14,16 @@
       - /etc/yum.repos.d/
     evidence_files:
       - /var/log/messages
+      - /var/log/yum.log
+      - /var/log/boot.log
       - /proc/cpuinfo
       - /proc/meminfo
+      - /proc/cmdline
+      - /proc/version
+      - /proc/devices
+      - /proc/partitions
       - /etc/hosts
+      - /etc/os-release
       - /etc/machine-id
   roles:
     - qe-evidence
@@ -27,14 +34,26 @@
   user: root
   vars:
     evidence_dirs:
-      - /var/log/httpd/
       - /etc/tendrl/
+      - /etc/httpd/
+      - /etc/etcd/
+      - /etc/carbon/
+      - /etc/graphite-web/
+      - /etc/ceph-installer/
+      - /var/log/tendrl
+      - /var/log/httpd/
+      - /var/log/carbon/
+      - /var/log/graphite-web/
+      - /var/log/rabbitmq
     evidence_files:
-      - /etc/etcd/etcd.conf
+      - /etc/collectd.conf
     evidence_journald_services:
-      - tendrl-apid
+      - tendrl-api
+      - tendrl-performance-monitoring
+      - ceph-installer
+      - ceph-installer-celery
   roles:
-    - role: qe-evidence
+    - qe-evidence
     - qe-evidence-probe-journald
 
 - name: Download logs from Gluster Storage machines
@@ -51,13 +70,22 @@
       - tendrl-node-agent
       - tendrl-performance-monitoring
   roles:
-    - role: qe-evidence
+    - qe-evidence
     - qe-evidence-probe-journald
 
-#- name: Download logs from Ceph Storage machines
-#  hosts: ceph
-#  user: root
-#  vars:
-#    evidence_dirs:
-#  roles:
-#   - role: qe-evidence
+- name: Download logs from Ceph Storage machines
+  hosts: ceph
+  user: root
+  vars:
+    evidence_dirs:
+      - /etc/tendrl/
+      - /etc/ceph/
+      - /var/log/tendrl/
+      - /var/log/ceph/
+    evidence_journald_services:
+      - tendrl-ceph-integration
+      - tendrl-node-agent
+      - tendrl-performance-monitoring
+  roles:
+   - qe-evidence
+   - qe-evidence-probe-journald

--- a/qe_evidence.yml
+++ b/qe_evidence.yml
@@ -1,9 +1,0 @@
----
-
-# Minimal playbook for qe-evidence role (role defaults are used)
-
-- name: Download all logs and all configuration from all machines
-  hosts: all
-  user: root
-  roles:
-    - qe-evidence

--- a/roles/qe-evidence-probe/files/tendrl-devel-debug.py
+++ b/roles/qe-evidence-probe/files/tendrl-devel-debug.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python2
+
+# Based on *Information required for debugging issues on the Tendrl stack* wiki
+# page:
+# https://github.com/Tendrl/documentation/wiki/Information-required-for-debugging-issues-on-the-Tendrl-stack
+
+import socket
+import subprocess
+
+print "socket.getfqdn() returns:", socket.getfqdn()
+print "socket.gethostname() returns:", socket.gethostname()
+
+ip_output = subprocess.check_output(['ip', 'a', 's']).splitlines()
+ipv4_nets = [line.strip().split(' ')[1] for line in ip_output if 'global' in line and line.startswith('    inet ')]
+for network in ipv4_nets:
+    ip_addr, prefix = network.split('/')
+    value = socket.gethostbyaddr(ip_addr)
+    print "socket.gethostbyaddr({}) returns:".format(ip_addr), value

--- a/roles/qe-evidence-probe/tasks/main.yml
+++ b/roles/qe-evidence-probe/tasks/main.yml
@@ -36,6 +36,14 @@
   retries: 5
   delay: 5
 
+# Transfer tendrl-devel-debug.py script
+
+- name: Copy tendrl-devel-debug.py into /tmp/usmqe
+  copy:
+    src=tendrl-devel-debug.py
+    dest=/tmp/usmqe/tendrl-devel-debug.py
+    mode=555
+
 # So that we can run few data dumps/probes and store results into /tmp/usmqe/
 
 - name: Probe remote machine
@@ -58,6 +66,7 @@
    - { cmd: 'iptables -nvL', out: 'iptables-nvL' }
    - { cmd: 'lsof -i', out: 'lsof-i' }
    - { cmd: 'netstat -ntlp', out: 'netstat-ntlp' }
+   - { cmd: '/tmp/usmqe/tendrl-devel-debug.py', out: 'tendrl-devel-debug' }
 
 # Gluster only checks
 

--- a/roles/qe-evidence-probe/tasks/main.yml
+++ b/roles/qe-evidence-probe/tasks/main.yml
@@ -59,6 +59,25 @@
    - { cmd: 'lsof -i', out: 'lsof-i' }
    - { cmd: 'netstat -ntlp', out: 'netstat-ntlp' }
 
+# Gluster only checks
+
+- name: Check if gluster is installed
+  command: rpm -q glusterfs-cli
+  register: rpm_q_glusterfs_cli
+  changed_when: False
+  failed_when: rpm_q_glusterfs_cli.rc > 1
+
+- name: Probe remote machine if gluster is installed
+  shell: '{{ item.cmd }} > {{ item.out }}'
+  args:
+    chdir: /tmp/usmqe/
+    # creates: /tmp/usmqe/{{ item.out }}
+  when: rpm_q_glusterfs_cli.rc == 0
+  with_items:
+   - { cmd: 'gluster peer status', out: 'gluster-peer-status' }
+   - { cmd: 'gluster pool list', out: 'gluster-pool-list' }
+   - { cmd: 'gluster volume list', out: 'gluster-volume-list' }
+
 # Now rsync all the data dumps from remote machines.
 
 - name: Rsync result of the probe into local machine

--- a/roles/qe-evidence-probe/tasks/main.yml
+++ b/roles/qe-evidence-probe/tasks/main.yml
@@ -26,9 +26,11 @@
   yum: name={{ item }} state=present
   with_items:
    - psmisc
+   - procps-ng
    - policycoreutils
    - policycoreutils-python
    - lsof
+   - net-tools
   register: task_result
   until: task_result|success
   retries: 5
@@ -47,6 +49,7 @@
    - { cmd: 'hostname', out: 'hostname' }
    - { cmd: 'lsblk', out: 'lsblk' }
    - { cmd: 'pstree -aplZ', out: 'pstree' }
+   - { cmd: 'ps aufx', out: 'ps-aufx' }
    - { cmd: 'systemctl status', out: 'systemctl-status' }
    - { cmd: 'sestatus', out: 'sestatus' }
    - { cmd: 'semanage permissive -l', out: 'semanage-permissive' }
@@ -54,6 +57,7 @@
    - { cmd: 'ip route s', out: 'ip-route-show' }
    - { cmd: 'iptables -nvL', out: 'iptables-nvL' }
    - { cmd: 'lsof -i', out: 'lsof-i' }
+   - { cmd: 'netstat -ntlp', out: 'netstat-ntlp' }
 
 # Now rsync all the data dumps from remote machines.
 

--- a/roles/qe-evidence/tasks/main.yml
+++ b/roles/qe-evidence/tasks/main.yml
@@ -35,4 +35,5 @@
     src={{ item }}
     dest={{ evidence_target }}/
     fail_on_missing=no
+    validate_checksum=no
   with_items: '{{ evidence_files }}'


### PR DESCRIPTION
This update of envidence playbook for Tendrl includes:

* extend evidence probe role to provide all details in particular format as documented in https://github.com/Tendrl/documentation/wiki/Information-required-for-debugging-issues-on-the-Tendrl-stack
* fix of checksum issue
* list of directories and files were updated

Example of usage:

```
$ ansible-playbook -i mbukatov-usm1.hosts qe_evidence.tendrl.yml  --extra-vars='evidence_target=/home/martin/tmp/evidence-foo'
$ cd ~/tmp/evidence-foo
$ ls
mbukatov-usm1-gl1.example.com  mbukatov-usm1-mon1.example.com  mbukatov-usm1-osd2.example.com
mbukatov-usm1-gl2.example.com  mbukatov-usm1-mon2.example.com  mbukatov-usm1-osd3.example.com
mbukatov-usm1-gl3.example.com  mbukatov-usm1-mon3.example.com  mbukatov-usm1-osd4.example.com
mbukatov-usm1-gl4.example.com  mbukatov-usm1-osd1.example.com  mbukatov-usm1-server.example.com
$ cat mbukatov-usm1-gl3.example.com/tmp/usmqe/tendrl-devel-debug
socket.getfqdn() returns: mbukatov-usm1-gl3.example.com
socket.gethostname() returns: mbukatov-usm1-gl3.example.com
socket.gethostbyaddr(10.34.108.62) returns: ('mbukatov-usm1-gl3.example.com', [], ['10.34.108.62'])
socket.gethostbyaddr(10.34.108.216) returns: ('mbukatov-usm1-gl3.example.com', [], ['10.34.108.62', '10.34.108.216'])
$ cat mbukatov-usm1-gl3.example.com/tmp/usmqe/lsblk 
NAME   MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
vda    253:0    0  20G  0 disk 
└─vda1 253:1    0  20G  0 part /
vdb    253:16   0   1T  0 disk 
vdc    253:32   0   1T  0 disk 
vdd    253:48   0   1T  0 disk 
vde    253:64   0   1T  0 disk 
vdf    253:80   0   1T  0 disk 
vdg    253:96   0   1T  0 disk 
vdh    253:112  0   1T  0 disk 
vdi    253:128  0   1T  0 disk 
vdj    253:144  0   1T  0 disk 
vdk    253:160  0   1T  0 disk
$ cat mbukatov-usm1-gl3.example.com/tmp/usmqe/gluster-pool-list 
UUID					Hostname                                      	State
633313bd-e9f1-45fa-9dd0-8e2ce6493f41	mbukatov-usm1-gl1.example.com	Connected 
36ed118d-2a8a-4f32-85eb-6091fddf3c99	mbukatov-usm1-gl2.example.com	Connected 
7ec5b54f-a639-496e-b756-682cdcae08e7	mbukatov-usm1-gl4.example.com	Connected 
ccd681a8-b8cd-4619-ae42-8be730581782	localhost                                     	Connected
$ du -sh ~/tmp/evidence-foo
1.1G	/home/martin/tmp/evidence-foo
```

Addressing https://github.com/Tendrl/usmqe-setup/issues/112