### PR TITLE
support for dedicated perf mon machine

### DIFF
--- a/tendrl.yml
+++ b/tendrl.yml
@@ -8,18 +8,30 @@
   remote_user: root
   vars:
     etcd_ip_address: "{{ ansible_default_ipv4.address }}"
-    tendrl_api_ip_address: "{{ etcd_ip_address }}"
   roles:
     - { role: epel, epel_enabled: 1 }
     - qe-tendrl-repo
     - ceph-installer # TODO: make it optional (when we don't deploy ceph)
     - tendrl-server
-    - tendrl-performance-monitoring
   post_tasks:
     - debug: var=hostvars[groups['usm_server'][0]]['admin_password']
     - name: Copy usm.ini template
       local_action: template src=./templates/usm.ini.j2 dest=./usm.ini
       when: hostvars[groups['usm_server'][0]]['admin_password'].changed
+
+#
+# Install Tendrl Performance Monitoring machine
+#
+
+- hosts: usm_perfmon
+  remote_user: root
+  vars:
+    etcd_ip_address: "{{ hostvars[groups['usm_server'][0]].ansible_default_ipv4.address }}"
+    tendrl_api_ip_address: "{{ etcd_ip_address }}"
+  roles:
+    - { role: epel, epel_enabled: 1 }
+    - qe-tendrl-repo
+    - tendrl-performance-monitoring
 
 #
 # Install Tendrl on storage nodes


### PR DESCRIPTION
Installation of *Tendrl Performance Monitoring* is done only on machines in `usm_perfmon` ansible inventory group, so that installation of dedicated monitoring machine is possible. To continue using collocated Tendrl Server with Monitoring, add the server machine into this new group.